### PR TITLE
Fixed strncpy buffer overflow

### DIFF
--- a/rtl_acars_ng.c
+++ b/rtl_acars_ng.c
@@ -1268,8 +1268,8 @@ aircraft_finished:
 	while ((ind<7)/*&&(msg->fid[ind]=='0')*/) 
 	{
 	    regtmp[2]='0';
-	    if (ind>1) strncpy(&regtmp[3],&msg->fid[ind],7-ind);
-	    else strncpy(&regtmp[2],&msg->fid[ind+1],7);
+	    if (ind>1) strncpy(&regtmp[3], &msg->fid[ind], 7-ind);
+	    else strncpy(&regtmp[2], &msg->fid[ind+1], 4);
 	    ind++;
 	    if (strlen(msg->fid)>1) while(acars_flights[i].flightid){
 		if ((!found)&&(!strncmp(acars_flights[i].flightid, regtmp,2))&&(correct)) {


### PR DESCRIPTION
The compiler was throwing a warning about a buffer overflow.

-Ryan

```
09:59 $ make
gcc -o rtl_acars_ng rtl_acars_ng.c `pkg-config --cflags --libs librtlsdr libusb` -lpthread -lm -O2
In file included from /usr/include/string.h:638:0,
                 from rtl_acars_ng.c:26:
In function ‘strncpy’,
    inlined from ‘print_mesg’ at rtl_acars_ng.c:1272:18:
/usr/include/i386-linux-gnu/bits/string3.h:120:3: warning: call to __builtin___strncpy_chk will always overflow destination buffer [enabled by default]
   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
   ^
```
